### PR TITLE
Support multiple rule paths as parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ groups:
 
 The glob matching rules are per Go's [filepath.Glob](https://pkg.go.dev/path/filepath#Glob). (Note that you may need to quote the globs to prevent your shell expanding them first.)
 
+**Note that the default behaviour has changed** - if `prometheus_merge` no longer produces output, you may need to change your folder paths to be globs (for example, `alerts/` to `alerts/*`).
+
 The output is printed to stdout.
 
 ### Ansible integration

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The program loops over all of the alerting rules until it finds an override rule
 
 # Usage
 
-The application loads all of the valid files from the specified directories and applies overrides if they are defined.
+The application loads all of the valid files matching the specified globs and applies overrides if they are defined.
 
 For examples look at `examples` directory.
 
@@ -35,8 +35,10 @@ groups:
 ## Running the program
 
 ```
-./prometheus_merge <path_to_rules> [<path_to_more_rules>]
+./prometheus_merge <glob> [<glob>]
 ```
+
+The glob matching rules are per Go's [filepath.Glob](https://pkg.go.dev/path/filepath#Glob). (Note that you may need to quote the globs to prevent your shell expanding them first.)
 
 The output is printed to stdout.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The program loops over all of the alerting rules until it finds an override rule
 
 # Usage
 
-The application loads all of the valid files from specified directory and applies overrides if they are defined.
+The application loads all of the valid files from the specified directories and applies overrides if they are defined.
 
 For examples look at `examples` directory.
 
@@ -35,7 +35,7 @@ groups:
 ## Running the program
 
 ```
-./prometheus_merge <path_to_rules>
+./prometheus_merge <path_to_rules> [<path_to_more_rules>]
 ```
 
 The output is printed to stdout.

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -139,15 +140,17 @@ func NegateFilterExpression(input string) string {
 	return strings.Join(exprFilterBodyElements[:], ",")
 }
 
-func getFilePaths(rootPath string) []string {
+func getFilePaths(roots []string) []string {
 	var filePaths []string
 
-	files, err := ioutil.ReadDir(rootPath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	for _, f := range files {
-		filePaths = append(filePaths, rootPath+"/"+f.Name())
+	for _, root := range roots {
+		files, err := ioutil.ReadDir(root)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, f := range files {
+			filePaths = append(filePaths, root+string(filepath.Separator)+f.Name())
+		}
 	}
 
 	return filePaths
@@ -168,12 +171,11 @@ func loadAlertFile(filePath string) *AlertFile {
 
 func main() {
 
-	if len(os.Args) != 2 {
+	if len(os.Args) < 2 {
 		panic("No arguments provided")
 	}
 
-	filePaths := os.Args[1]
-	files := getFilePaths(filePaths)
+	files := getFilePaths(os.Args[1:])
 
 	var alertFiles []AlertFile
 

--- a/main.go
+++ b/main.go
@@ -140,16 +140,20 @@ func NegateFilterExpression(input string) string {
 	return strings.Join(exprFilterBodyElements[:], ",")
 }
 
-func getFilePaths(roots []string) []string {
+func getFilePaths(globs []string) []string {
 	var filePaths []string
 
-	for _, root := range roots {
-		files, err := ioutil.ReadDir(root)
+	for _, root := range globs {
+		files, err := filepath.Glob(root)
 		if err != nil {
 			log.Fatal(err)
 		}
 		for _, f := range files {
-			filePaths = append(filePaths, root+string(filepath.Separator)+f.Name())
+			abspath, err := filepath.Abs(f)
+			if err != nil {
+				log.Fatal(err)
+			}
+			filePaths = append(filePaths, abspath)
 		}
 	}
 


### PR DESCRIPTION
This PR adds support for passing multiple directories with rules, to enable overrides to be better organised. They are all merged together as if they were in one directory.

Resolves #4.