### PR TITLE
feat(deployment): add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.18.0-alpine AS build-env
+ENV GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+COPY . /build
+WORKDIR /build
+RUN go build -o prometheus_alert_overrider main.go
+
+FROM gcr.io/distroless/static
+WORKDIR /app
+COPY --from=build-env /build/prometheus_alert_overrider /app
+ENTRYPOINT ["./prometheus_alert_overrider"]


### PR DESCRIPTION
Running `docker build` provides a small (5.32MB) container image.

Can be tested with the existing codebase as follows:

```
docker run -v `pwd`/examples:/app/examples test/prometheus-alert-overrider:local examples/*
```

A sample container image can be found at [saikolab/prometheus-alert-overrider](https://hub.docker.com/r/saikolab/prometheus-alert-overrider).